### PR TITLE
Simple CORS support, allowing requests from https://myvoice.graynorton.com

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,10 @@ module ReversePhoneBank
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.action_dispatch.default_headers = {
+      'Access-Control-Allow-Origin' => 'https://myvoice.graynorton.com',
+      'Access-Control-Request-Method' => %w{GET POST OPTIONS}.join(",")
+    }
   end
 end


### PR DESCRIPTION
Might be nice to do something smarter, like maintain an array of supported hosts in the Rails app and return the appropriate header when we get a request from any supported host -- but this basic change should allow end-to-end testing of the frontend and backend code.